### PR TITLE
correct representation for char arrays

### DIFF
--- a/pkg/utils/cdc_message.go
+++ b/pkg/utils/cdc_message.go
@@ -262,7 +262,7 @@ func DecodeValue(data []byte, dataType uint32) (interface{}, error) {
 		var result interface{}
 		err := json.Unmarshal(data, &result)
 		return result, err
-	case pgtype.TextArrayOID, pgtype.VarcharArrayOID:
+	case pgtype.TextArrayOID, pgtype.VarcharArrayOID, pgtype.BPCharArrayOID, pgtype.QCharArrayOID:
 		return DecodeTextArray(data)
 	case pgtype.Int2ArrayOID, pgtype.Int4ArrayOID, pgtype.Int8ArrayOID, pgtype.Float4ArrayOID, pgtype.Float8ArrayOID, pgtype.BoolArrayOID:
 		return DecodeArray(data, dataType)


### PR DESCRIPTION
Simple fix for char arrays to treat them like text and varchar. Previously, I was getting a bunch of representation errors for the sql string value.